### PR TITLE
Add Agent Builder Comparison Blog Post

### DIFF
--- a/content/posts/agent-builder-comparison.md
+++ b/content/posts/agent-builder-comparison.md
@@ -1,0 +1,227 @@
+---
+title: "Choosing the Right AI Agent Builder: OpenAI Agent Kit vs Databricks Agent Bricks vs LangSmith"
+date: 2025-10-30T04:10:00Z
+author:
+authorLink:
+description: "Compare OpenAI Agent Kit, Databricks Agent Bricks, and LangSmith Agent Builder to find the right AI agent development platform for your use case. Detailed feature comparison covering ease of use, model options, integrations, and deployment strategies."
+tags:
+- AI Agents
+- OpenAI
+- Databricks
+- LangChain
+- LangSmith
+categories:
+- Tutorial
+draft: false
+---
+
+***
+#### Need help choosing between OpenAI Agent Kit, Databricks Agent Bricks, and LangSmith Agent Builder? This comprehensive guide compares all three platforms to help you select the right tool for building AI agents in your organization.
+
+***
+
+## Introduction
+
+The AI agent landscape has exploded with new tools and frameworks, each promising to simplify the development of intelligent, autonomous systems. Whether you're building a customer service chatbot, automating data analysis workflows, or creating complex multi-agent systems, choosing the right platform can make or break your project.
+
+In this guide, we'll compare three prominent AI agent builders: OpenAI Agent Kit, Databricks Agent Bricks, and LangSmith Agent Builder. Each takes a different approach to agent development, targeting distinct use cases and developer personas. By understanding their strengths and trade-offs, you'll be equipped to make an informed decision for your specific needs.
+
+***
+
+## Platform Overview
+
+### OpenAI Agent Kit
+
+OpenAI Agent Kit is a beginner-friendly, visual workflow builder designed for creating conversational AI agents powered by GPT models. It prioritizes ease of use and rapid deployment, making it ideal for teams that want to quickly prototype and launch simple to moderately complex agents without deep technical expertise.
+
+**Best for**: Chat bots, FAQ systems, simple automations, and rapid prototyping of conversational interfaces.
+
+### Databricks Agent Bricks
+
+Databricks Agent Bricks is an enterprise-scale, domain-specific agent system built for data-driven use cases. It's deeply integrated with the Databricks platform, allowing agents to leverage your organization's custom datasets, data lakehouse architecture, and unified governance. This platform excels when your agents need to work with large-scale data and analytics.
+
+**Best for**: Enterprise data and analytics agents, business intelligence automation, and data-driven decision systems.
+
+### LangSmith Agent Builder
+
+LangSmith Agent Builder is a modular framework from LangChain designed for developers building advanced agent architectures. It supports persistent memory, self-updating agents, and complex orchestration patterns. This platform is ideal for teams with strong technical capabilities who need maximum flexibility and control.
+
+**Best for**: Custom workflows, research applications, developer tools, and complex business logic requiring sophisticated agent behaviors.
+
+***
+
+## Feature Comparison
+
+| Feature | OpenAI Agent Kit | Databricks Agent Bricks | LangSmith Agent Builder |
+|---------|-----------------|------------------------|------------------------|
+| **Main Focus** | Conversational AI Agents | Domain-Specific Enterprise Agents | Modular, Persistent, Multi-agent Systems |
+| **Ease of Use** | Beginner-Friendly | Streamlined for Databricks users | Requires developer expertise |
+| **Model Options** | GPT Models only | Multiple models incl. fine-tuning | Flexible, multi-model support |
+| **Integration** | APIs, Web Search, Embedding | Deep Databricks/Data Integration | Wide, extensible, connects to APIs |
+| **Memory & Adaptation** | Stateless | Data-driven, some optimization loops | Persistent memory, self-updating |
+| **Workflow Design** | Visual Canvas | Automated, guided templates | Modular, triggers, sub-agents |
+| **Deployment** | Instant web embed/API | Optimized endpoint on Databricks | Flexible, language-agnostic |
+| **Evaluation & Guardrails** | Built-In Guardrails, Eval | Automated benchmarks, cost controls | Custom evals, modular guardrails |
+
+***
+
+## Deep Dive: When to Choose Each Platform
+
+### Choose OpenAI Agent Kit When:
+
+- **You need to ship fast**: Visual canvas and drag-and-drop interfaces mean you can go from concept to deployment in hours or days, not weeks
+- **Your team is non-technical**: Product managers, designers, and business analysts can build functional agents without writing code
+- **You're building conversational interfaces**: Customer support bots, FAQ assistants, and simple chatbots are the sweet spot
+- **You're committed to OpenAI's ecosystem**: If you're already using GPT-4 and want seamless integration
+- **Budget is a consideration**: Simple pricing based on API usage makes cost predictable
+
+**Limitations to consider**:
+- Limited to GPT models only—no flexibility for other LLMs
+- Stateless architecture means agents don't learn or adapt over time
+- May struggle with complex workflows requiring multiple decision points
+- Less suitable for agents that need to interact with large-scale data systems
+
+***
+
+### Choose Databricks Agent Bricks When:
+
+- **Your agents need data access**: Built on top of Delta Lake and Unity Catalog, agents can securely query your data warehouse
+- **You're already using Databricks**: Native integration means less infrastructure overhead and unified governance
+- **Enterprise scale matters**: Designed for production workloads with automated benchmarking and cost controls
+- **Data governance is critical**: Row-level security, column masking, and audit trails are built-in
+- **You need fine-tuned models**: Support for custom model training on your domain-specific data
+
+**Limitations to consider**:
+- Requires Databricks platform—higher barrier to entry if you're not already a customer
+- Steeper learning curve compared to visual no-code tools
+- Best suited for structured data use cases rather than general conversation
+- Less flexibility for non-data-centric agent workflows
+
+***
+
+### Choose LangSmith Agent Builder When:
+
+- **You need advanced agent capabilities**: Persistent memory, self-reflection, and multi-agent orchestration
+- **Your team has strong technical skills**: Developers comfortable with Python and LangChain's paradigms will thrive
+- **You require model flexibility**: Easily swap between OpenAI, Anthropic, open-source models, or custom LLMs
+- **Complex workflows are your focus**: Multi-step reasoning, tool chains, and conditional logic are first-class citizens
+- **You want observability and debugging**: LangSmith provides detailed traces and monitoring for agent behavior
+
+**Limitations to consider**:
+- Steepest learning curve—requires understanding of LangChain concepts and patterns
+- More code-heavy approach compared to visual builders
+- May be overkill for simple conversational use cases
+- Requires more infrastructure setup and maintenance
+
+***
+
+## Model Support and Flexibility
+
+**OpenAI Agent Kit** locks you into OpenAI's GPT models. This simplifies decision-making but limits flexibility. If you need to experiment with different models or reduce dependency on a single vendor, this could be a constraint.
+
+**Databricks Agent Bricks** supports multiple model types and includes fine-tuning capabilities. You can train models on your proprietary data, which is valuable for domain-specific applications where generic LLMs may underperform.
+
+**LangSmith Agent Builder** offers the most flexibility, supporting virtually any LLM through LangChain's unified interface. You can mix and match models for different parts of your agent workflow, optimizing for cost and performance.
+
+***
+
+## Integration Capabilities
+
+**OpenAI Agent Kit** provides straightforward integrations with common APIs, web search, and embedding services. It's designed for simplicity, so integrations are pre-built but somewhat limited in scope.
+
+**Databricks Agent Bricks** shines with deep data integration. Agents can query Delta tables, run SQL, access Unity Catalog, and leverage the entire Databricks ecosystem. This is unmatched for data-intensive use cases.
+
+**LangSmith Agent Builder** offers the widest range of extensible integrations. The LangChain ecosystem includes hundreds of pre-built integrations, and you can easily add custom tools and APIs as needed.
+
+***
+
+## Memory and Learning
+
+**OpenAI Agent Kit** is stateless, meaning each interaction is independent. This simplifies architecture but means agents don't learn from past conversations or adapt behavior over time.
+
+**Databricks Agent Bricks** can leverage data-driven optimization loops, using historical data and user feedback to improve responses. While not fully autonomous learning, it supports iterative improvement.
+
+**LangSmith Agent Builder** supports persistent memory and self-updating behaviors. Agents can maintain conversation history, learn from interactions, and even modify their own prompts or tools based on feedback. This is the most advanced approach but requires careful design to avoid unexpected behaviors.
+
+***
+
+## Deployment and Operations
+
+**OpenAI Agent Kit** excels at deployment simplicity. You can instantly embed agents in web pages or expose them via API endpoints. No infrastructure management is required—OpenAI handles hosting and scaling.
+
+**Databricks Agent Bricks** deploys as optimized endpoints within Databricks, leveraging your existing infrastructure and governance policies. This is ideal if you're already managing production workloads on Databricks but adds complexity if you're not.
+
+**LangSmith Agent Builder** is the most flexible for deployment. You can deploy agents as APIs, integrate them into existing applications, or run them as serverless functions. However, you're responsible for infrastructure, monitoring, and scaling.
+
+***
+
+## Evaluation and Guardrails
+
+All three platforms recognize that AI agents need evaluation and safety mechanisms, but they approach this differently:
+
+**OpenAI Agent Kit** includes built-in guardrails and evaluation tools designed for conversational safety—filtering harmful content, detecting jailbreak attempts, and ensuring appropriate responses.
+
+**Databricks Agent Bricks** provides automated benchmarking and cost controls, allowing you to track agent performance against business metrics and manage compute expenses at scale.
+
+**LangSmith Agent Builder** offers custom evaluation frameworks and modular guardrails. You have full control to define success metrics, build test suites, and implement safety checks tailored to your use case.
+
+***
+
+## Pricing Considerations
+
+**OpenAI Agent Kit**: Pay-per-use pricing based on OpenAI API calls. Predictable but can scale quickly with high-volume applications.
+
+**Databricks Agent Bricks**: Pricing tied to Databricks compute (DBUs). Cost-effective if you're already on Databricks; potentially expensive if adopting solely for agents.
+
+**LangSmith Agent Builder**: Pricing based on LangSmith tracing and monitoring usage, plus underlying model API costs. Most flexible but requires careful cost management across multiple services.
+
+***
+
+## Making Your Decision
+
+Here's a decision framework to guide your choice:
+
+### Start with OpenAI Agent Kit if:
+- You need a conversational chatbot or simple automation
+- Your team lacks deep technical expertise
+- Time to market is critical
+- You're comfortable with OpenAI's ecosystem
+
+### Choose Databricks Agent Bricks if:
+- Your agents need to work with large-scale data
+- You're already using Databricks for analytics
+- Enterprise governance and security are non-negotiable
+- You need domain-specific fine-tuned models
+
+### Select LangSmith Agent Builder if:
+- You're building complex, multi-step workflows
+- Your team has strong development capabilities
+- You need maximum flexibility and control
+- Advanced features like persistent memory are requirements
+
+***
+
+## Real-World Use Case Examples
+
+### Customer Support Bot (OpenAI Agent Kit)
+A mid-size SaaS company needs a customer support chatbot to handle common questions about billing, account management, and basic troubleshooting. OpenAI Agent Kit's visual builder allows their support team to create and refine the bot without developer resources.
+
+### Data Analytics Agent (Databricks Agent Bricks)
+A Fortune 500 retailer wants an agent that can answer business questions by querying their data lakehouse: "What were sales trends for Product X in Q3?" The agent needs to access sensitive data with proper governance. Databricks Agent Bricks provides secure data access and integration with existing BI workflows.
+
+### Research Assistant (LangSmith Agent Builder)
+A research lab is building an agent that can search academic papers, synthesize findings, maintain context across long conversations, and even suggest new research directions. LangSmith's persistent memory and flexible tool integration make this possible.
+
+***
+
+## Conclusion
+
+There's no one-size-fits-all answer when choosing an AI agent builder. OpenAI Agent Kit excels at rapid development of conversational interfaces, Databricks Agent Bricks is unmatched for enterprise data-driven agents, and LangSmith Agent Builder provides maximum flexibility for complex workflows.
+
+The right choice depends on your specific use case, team capabilities, existing infrastructure, and long-term requirements. Many organizations will eventually use multiple platforms for different agent applications, leveraging each tool's unique strengths.
+
+Start by clearly defining your agent's purpose, required capabilities, and constraints. Then match those requirements to the platform that best aligns with your needs. With the comparison and decision framework provided here, you're equipped to make an informed choice and start building effective AI agents for your organization.
+
+***
+
+*Have experience with these platforms? Reach out to share your insights or ask questions about implementing AI agents in your organization.*


### PR DESCRIPTION
This PR adds a comprehensive blog post comparing OpenAI Agent Kit, Databricks Agent Bricks, and LangSmith Agent Builder.

## Changes
- Created new blog post: `agent-builder-comparison.md`
- Includes detailed feature comparison table
- Provides decision framework for choosing the right platform
- Covers use cases, integration capabilities, and deployment strategies
- Includes SEO metadata and proper tagging

Closes #34

Generated with [Claude Code](https://claude.ai/code)