### PR TITLE
Add consulting menu item to config.toml (#40)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -63,13 +63,21 @@ URL = "s3://mcconnellweb.com/?region=us-east-1" #your bucket here
     title = "Portfolio"
     weight = 3
   [[menu.main]]
+    identifier = "consulting"
+    pre = ""
+    post = ""
+    name = "Consulting"
+    url = "https://stp-llc.org"
+    title = "Consulting"
+    weight = 4
+  [[menu.main]]
     identifier = "posts"
     pre = ""
     post = ""
     name = "Posts"
     url = "/posts/"
     title = "Posts"
-    weight = 4
+    weight = 5
   # [[menu.main]]
   #   identifier = "tags"
   #   pre = ""


### PR DESCRIPTION
- Introduced a new menu entry for "Consulting" with a dedicated URL and weight adjustment.
- Updated the weight of the "Posts" menu item to maintain proper ordering.

This enhances site navigation by providing direct access to consulting services.